### PR TITLE
Using Node Path module to get file extension

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var crypto = require('crypto');
 var fs = require('fs');
+var path = require('path');
 
 // # Simple functions for generating filenames.
 
@@ -12,7 +13,7 @@ function filenameFromBuffer (buffer, extension) {
 		.replace(/=/g, '')
 		.slice(0, 16);
 
-	if (extension) filename = filename + '.' + extension;
+	if (extension) filename = filename + extension;
 
 	return filename;
 }
@@ -51,6 +52,6 @@ exports.originalFilename = function (file) {
 exports.randomFilename = function (file, i, callback) {
 	crypto.randomBytes(16, function (err, data) {
 		if (err) return callback(err);
-		return callback(null, filenameFromBuffer(data, file.extension));
+		return callback(null, filenameFromBuffer(data, path.extname(file.originalname)));
 	});
 };

--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ exports.contentHashFilename = function (file, i, callback) {
 		if (calledCallback) return;
 		calledCallback = true;
 		// Data is a node Buffer.
-		callback(null, filenameFromBuffer(data, file.extension));
+		callback(null, filenameFromBuffer(data, path.extname(file.originalname)));
 	});
 };
 


### PR DESCRIPTION
Using Node's Path module to get file extension.
Replacing file.extension with path.extname(file.originalname). extname() handles all extension cases.
Because sometimes file.extension is undefined